### PR TITLE
transfer pet name

### DIFF
--- a/src/main/java/gay/nyako/nyakomod/item/PetSummonItem.java
+++ b/src/main/java/gay/nyako/nyakomod/item/PetSummonItem.java
@@ -69,6 +69,10 @@ public class PetSummonItem<T extends PetEntity> extends TrinketItem {
                 var pet = createPetMethod.create(stack, entity);
                 entity.world.spawnEntity(pet);
 
+                if (stack.hasCustomName()) {
+                    pet.setCustomName(stack.getName());
+                }
+
                 summonedPet = pet;
             }
         }


### PR DESCRIPTION
Allows pet summoners to be named, which will in turn transfer the name to the pet.

Note: while the custom name of pet sprites does get set, the model doesn't allow for the name to be displayed. This should be resolved in the future (low priority)